### PR TITLE
Add WooCommerce SMM panel connector plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# smmpanelwordpress
-smmpanelwordpress
+# WooCommerce SMM Panel Connector
+
+WordPress eklentisi olarak WooCommerce mağazanızı Perfect Panel uyumlu SMM panellerine bağlamak için tasarlandı. Bu depo içinde yer alan `wp-content/plugins/smm-panel-connector` klasörünü WordPress kurulumunuzdaki `wp-content/plugins` dizinine kopyalayarak kullanabilirsiniz.
+
+## Özellikler
+
+- API URL ve API anahtarını yönetim panelinden tanımlayabilme
+- Perfect Panel ve yaygın SMM panel API v2 uç noktalarıyla uyumluluk
+- Hizmetleri WooCommerce basit ürünleri olarak otomatik senkronizasyon
+- Fiyat çarpanı veya sabit tutar ile otomatik fiyatlandırma
+- Varsayılan kategori ataması ve stok davranışı ayarları
+- Manuel senkronizasyon ve AJAX üzerinden bağlantı testi
+- WP-Cron ile planlanmış otomatik senkronizasyon
+
+## Kurulum
+
+1. Depoyu bilgisayarınıza klonlayın veya zip olarak indirin.
+2. `wp-content/plugins/smm-panel-connector` klasörünü WordPress kurulumunuzdaki aynı dizine kopyalayın.
+3. WordPress yönetim panelinden **Eklentiler > Yüklü Eklentiler** sayfasına gidin ve **WooCommerce SMM Panel Connector** eklentisini etkinleştirin.
+4. WooCommerce menüsü altında yer alan **SMM Panel** sayfasından API URL ve API anahtarınızı girin.
+5. Senkronizasyon ayarlarını yapıp kaydedin, ardından isteğe bağlı olarak manuel senkronizasyon başlatın.
+
+## API Gereksinimleri
+
+Eklenti Perfect Panel ve yaygın SMM panel servislerinin sunduğu API v2 ile çalışır. Çoğu panel aşağıdaki uç noktaları destekler:
+
+- `balance` – Bağlantı testi ve bakiye sorgusu.
+- `services` – Servis listesini döndürür.
+
+Eklenti `services` uç noktasından dönen `id`, `name`, `rate`, `min`, `max`, `type`, `status`, `description` alanlarını kullanır. Bu alanlar paneller arasında farklılık gösterebilir, eksik alanlar otomatik olarak atlanır.
+
+## Geliştirme
+
+- Kod standartları WordPress PHP kod standartlarını takip eder.
+- Ayarlar `smmpw_settings` opsiyonunda saklanır.
+- Cron zamanlamaları için ek olarak “Her 15 Dakika” ve “Günde İki Kez” seçenekleri tanımlanır.
+
+Pull request gönderirken kod stilini korumaya ve gereksiz değişiklik yapmamaya özen gösterin.

--- a/wp-content/plugins/smm-panel-connector/includes/class-smmpw-service-sync.php
+++ b/wp-content/plugins/smm-panel-connector/includes/class-smmpw-service-sync.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Handles synchronization between WooCommerce and remote SMM panels.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'SMMPW_Service_Sync' ) ) {
+    /**
+     * Service synchronization class.
+     */
+    class SMMPW_Service_Sync {
+        /**
+         * Plugin settings.
+         *
+         * @var array
+         */
+        private $settings = array();
+
+        /**
+         * Constructor.
+         *
+         * @param array $settings Plugin settings.
+         */
+        public function __construct( $settings ) {
+            $this->settings = $settings;
+        }
+
+        /**
+         * Ping the remote API for connectivity checks.
+         *
+         * @return true|WP_Error
+         */
+        public function ping() {
+            $response = $this->request( 'balance' );
+
+            if ( is_wp_error( $response ) ) {
+                return $response;
+            }
+
+            $code = wp_remote_retrieve_response_code( $response );
+            if ( 200 !== $code ) {
+                return new WP_Error( 'smmpw_ping_failed', sprintf( __( 'Unexpected response code: %d', 'smmpw' ), $code ) );
+            }
+
+            return true;
+        }
+
+        /**
+         * Synchronize services with WooCommerce products.
+         *
+         * @return bool
+         */
+        public function sync() {
+            $services = $this->fetch_services();
+
+            if ( is_wp_error( $services ) ) {
+                error_log( 'SMMPW sync error: ' . $services->get_error_message() );
+                return false;
+            }
+
+            if ( empty( $services ) ) {
+                return true;
+            }
+
+            foreach ( $services as $service ) {
+                $this->upsert_product_from_service( $service );
+            }
+
+            return true;
+        }
+
+        /**
+         * Fetch services from the remote panel.
+         *
+         * @return array|WP_Error
+         */
+        private function fetch_services() {
+            $response = $this->request( 'services' );
+
+            if ( is_wp_error( $response ) ) {
+                return $response;
+            }
+
+            $data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+            if ( null === $data ) {
+                return new WP_Error( 'smmpw_invalid_response', __( 'Invalid response received from API.', 'smmpw' ) );
+            }
+
+            if ( isset( $data['error'] ) ) {
+                return new WP_Error( 'smmpw_api_error', $data['error'] );
+            }
+
+            // Perfect Panel returns array of services.
+            if ( isset( $data['services'] ) ) {
+                return $data['services'];
+            }
+
+            return $data;
+        }
+
+        /**
+         * Create or update WooCommerce product based on a service payload.
+         *
+         * @param array $service Service data.
+         */
+        private function upsert_product_from_service( $service ) {
+            if ( empty( $service['id'] ) ) {
+                return;
+            }
+
+            $product_id = $this->get_product_by_service_id( $service['id'] );
+            $product    = $product_id ? wc_get_product( $product_id ) : new WC_Product_Simple();
+
+            $product->set_name( sanitize_text_field( $service['name'] ?? sprintf( __( 'Service %d', 'smmpw' ), $service['id'] ) ) );
+            $product->set_status( 'publish' );
+            $product->set_catalog_visibility( 'visible' );
+            $product->set_virtual( true );
+            $product->set_sold_individually( false );
+
+            $product->update_meta_data( '_smmpw_service_id', absint( $service['id'] ) );
+            $product->update_meta_data( '_smmpw_service_type', sanitize_text_field( $service['type'] ?? '' ) );
+            $product->update_meta_data( '_smmpw_min', isset( $service['min'] ) ? intval( $service['min'] ) : 0 );
+            $product->update_meta_data( '_smmpw_max', isset( $service['max'] ) ? intval( $service['max'] ) : 0 );
+            $product->update_meta_data( '_smmpw_description', sanitize_textarea_field( $service['description'] ?? '' ) );
+
+            $price = $this->calculate_price( $service );
+
+            if ( $price > 0 ) {
+                $product->set_regular_price( wc_format_decimal( $price ) );
+            }
+
+            $stock_behavior = $this->settings['stock_behavior'] ?? 'in_stock';
+            switch ( $stock_behavior ) {
+                case 'out_of_stock':
+                    $product->set_stock_status( 'outofstock' );
+                    break;
+                case 'remote':
+                    if ( isset( $service['status'] ) && 'active' === strtolower( $service['status'] ) ) {
+                        $product->set_stock_status( 'instock' );
+                    } else {
+                        $product->set_stock_status( 'outofstock' );
+                    }
+                    break;
+                case 'in_stock':
+                default:
+                    $product->set_stock_status( 'instock' );
+                    break;
+            }
+
+            if ( ! empty( $this->settings['default_category'] ) ) {
+                $product->set_category_ids( array( intval( $this->settings['default_category'] ) ) );
+            }
+
+            $product->save();
+        }
+
+        /**
+         * Calculate WooCommerce price based on remote price and markup settings.
+         *
+         * @param array $service Service data.
+         *
+         * @return float
+         */
+        private function calculate_price( $service ) {
+            $price_field = isset( $service['rate'] ) ? floatval( $service['rate'] ) : 0.0;
+
+            if ( empty( $this->settings['sync_pricing'] ) ) {
+                return $price_field;
+            }
+
+            $markup_value = floatval( $this->settings['price_markup_value'] ?? 0 );
+            $markup_type  = $this->settings['price_markup_type'] ?? 'percent';
+
+            if ( 'fixed' === $markup_type ) {
+                $price_field += $markup_value;
+            } else {
+                $price_field += ( $price_field * ( $markup_value / 100 ) );
+            }
+
+            return max( 0, $price_field );
+        }
+
+        /**
+         * Finds a product with the given service ID stored in meta.
+         *
+         * @param int|string $service_id Service identifier.
+         *
+         * @return int|null
+         */
+        private function get_product_by_service_id( $service_id ) {
+            global $wpdb;
+
+            $meta_key   = '_smmpw_service_id';
+            $service_id = absint( $service_id );
+
+            $product_id = $wpdb->get_var( $wpdb->prepare(
+                "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %d LIMIT 1",
+                $meta_key,
+                $service_id
+            ) );
+
+            return $product_id ? intval( $product_id ) : null;
+        }
+
+        /**
+         * Execute a request against the remote API using POST.
+         *
+         * @param string $action API action (services, balance, add, etc.).
+         * @param array  $params Additional parameters.
+         *
+         * @return array|WP_Error
+         */
+        private function request( $action, $params = array() ) {
+            if ( empty( $this->settings['api_url'] ) || empty( $this->settings['api_key'] ) ) {
+                return new WP_Error( 'smmpw_missing_credentials', __( 'API credentials are missing.', 'smmpw' ) );
+            }
+
+            $body = wp_parse_args(
+                $params,
+                array(
+                    'key'    => $this->settings['api_key'],
+                    'action' => $action,
+                )
+            );
+
+            $response = wp_remote_post(
+                trailingslashit( $this->settings['api_url'] ),
+                array(
+                    'timeout' => 30,
+                    'body'    => $body,
+                )
+            );
+
+            if ( is_wp_error( $response ) ) {
+                return $response;
+            }
+
+            return $response;
+        }
+    }
+}

--- a/wp-content/plugins/smm-panel-connector/includes/class-smmpw-settings-page.php
+++ b/wp-content/plugins/smm-panel-connector/includes/class-smmpw-settings-page.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * Admin settings page for SMM Panel connector.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'SMMPW_Settings_Page' ) ) {
+    /**
+     * Handles the WooCommerce settings page integration.
+     */
+    class SMMPW_Settings_Page {
+        /**
+         * @var SMMPW_Settings_Page
+         */
+        private static $instance;
+
+        /**
+         * Singleton.
+         *
+         * @return SMMPW_Settings_Page
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Hook registration.
+         */
+        private function __construct() {
+            add_action( 'admin_menu', array( $this, 'add_menu_page' ), 99 );
+            add_action( 'admin_init', array( $this, 'register_fields' ) );
+        }
+
+        /**
+         * Adds the settings page under WooCommerce.
+         */
+        public function add_menu_page() {
+            add_submenu_page(
+                'woocommerce',
+                __( 'SMM Panel Connector', 'smmpw' ),
+                __( 'SMM Panel', 'smmpw' ),
+                'manage_woocommerce',
+                'smmpw-settings',
+                array( $this, 'render_page' )
+            );
+        }
+
+        /**
+         * Register settings sections and fields for the settings page.
+         */
+        public function register_fields() {
+            add_settings_section(
+                'smmpw_api_settings',
+                __( 'API Settings', 'smmpw' ),
+                '__return_false',
+                'smmpw-settings'
+            );
+
+            add_settings_field(
+                'api_url',
+                __( 'API URL', 'smmpw' ),
+                array( $this, 'render_text_field' ),
+                'smmpw-settings',
+                'smmpw_api_settings',
+                array(
+                    'label_for' => 'smmpw_api_url',
+                    'option'    => 'api_url',
+                    'type'      => 'url',
+                    'help'      => __( 'Example: https://panel.example.com/api/v2', 'smmpw' ),
+                )
+            );
+
+            add_settings_field(
+                'api_key',
+                __( 'API Key', 'smmpw' ),
+                array( $this, 'render_text_field' ),
+                'smmpw-settings',
+                'smmpw_api_settings',
+                array(
+                    'label_for' => 'smmpw_api_key',
+                    'option'    => 'api_key',
+                    'type'      => 'password',
+                    'help'      => __( 'Enter the API key generated in your SMM panel.', 'smmpw' ),
+                )
+            );
+
+            add_settings_field(
+                'default_category',
+                __( 'Default Product Category', 'smmpw' ),
+                array( $this, 'render_category_dropdown' ),
+                'smmpw-settings',
+                'smmpw_api_settings'
+            );
+
+            add_settings_section(
+                'smmpw_sync_settings',
+                __( 'Synchronization Options', 'smmpw' ),
+                '__return_false',
+                'smmpw-settings'
+            );
+
+            add_settings_field(
+                'sync_pricing',
+                __( 'Synchronize Pricing', 'smmpw' ),
+                array( $this, 'render_checkbox_field' ),
+                'smmpw-settings',
+                'smmpw_sync_settings',
+                array(
+                    'label_for' => 'smmpw_sync_pricing',
+                    'option'    => 'sync_pricing',
+                    'description' => __( 'Update WooCommerce product prices with each synchronization.', 'smmpw' ),
+                )
+            );
+
+            add_settings_field(
+                'price_markup_type',
+                __( 'Price Markup Type', 'smmpw' ),
+                array( $this, 'render_select_field' ),
+                'smmpw-settings',
+                'smmpw_sync_settings',
+                array(
+                    'label_for' => 'smmpw_price_markup_type',
+                    'option'    => 'price_markup_type',
+                    'options'   => array(
+                        'percent' => __( 'Percentage', 'smmpw' ),
+                        'fixed'   => __( 'Fixed amount', 'smmpw' ),
+                    ),
+                )
+            );
+
+            add_settings_field(
+                'price_markup_value',
+                __( 'Markup Value', 'smmpw' ),
+                array( $this, 'render_text_field' ),
+                'smmpw-settings',
+                'smmpw_sync_settings',
+                array(
+                    'label_for' => 'smmpw_price_markup_value',
+                    'option'    => 'price_markup_value',
+                    'type'      => 'number',
+                    'step'      => '0.01',
+                    'help'      => __( 'Value used with the selected markup type.', 'smmpw' ),
+                )
+            );
+
+            add_settings_field(
+                'stock_behavior',
+                __( 'Stock Management', 'smmpw' ),
+                array( $this, 'render_select_field' ),
+                'smmpw-settings',
+                'smmpw_sync_settings',
+                array(
+                    'label_for' => 'smmpw_stock_behavior',
+                    'option'    => 'stock_behavior',
+                    'options'   => array(
+                        'in_stock'     => __( 'Always in stock', 'smmpw' ),
+                        'out_of_stock' => __( 'Always out of stock', 'smmpw' ),
+                        'remote'       => __( 'Use remote availability (if provided)', 'smmpw' ),
+                    ),
+                )
+            );
+
+            add_settings_field(
+                'sync_schedule',
+                __( 'Sync Schedule', 'smmpw' ),
+                array( $this, 'render_select_field' ),
+                'smmpw-settings',
+                'smmpw_sync_settings',
+                array(
+                    'label_for' => 'smmpw_sync_schedule',
+                    'option'    => 'sync_schedule',
+                    'options'   => array(
+                        'quarter_hour' => __( 'Every 15 minutes', 'smmpw' ),
+                        'hourly'       => __( 'Hourly', 'smmpw' ),
+                        'twicedaily'   => __( 'Twice Daily', 'smmpw' ),
+                        'daily'        => __( 'Daily', 'smmpw' ),
+                    ),
+                )
+            );
+        }
+
+        /**
+         * Render the plugin settings page contents.
+         */
+        public function render_page() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                wp_die( esc_html__( 'You are not allowed to view this page.', 'smmpw' ) );
+            }
+
+            $settings = SMMPW_Plugin::instance()->get_settings();
+            ?>
+            <div class="wrap">
+                <h1><?php esc_html_e( 'WooCommerce SMM Panel Connector', 'smmpw' ); ?></h1>
+                <?php if ( isset( $_GET['synced'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
+                    <?php if ( '1' === $_GET['synced'] ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
+                        <div id="message" class="updated notice notice-success is-dismissible"><p><?php esc_html_e( 'Synchronization completed successfully.', 'smmpw' ); ?></p></div>
+                    <?php else : ?>
+                        <div id="message" class="error notice notice-error is-dismissible"><p><?php esc_html_e( 'Synchronization failed. Check logs for details.', 'smmpw' ); ?></p></div>
+                    <?php endif; ?>
+                <?php endif; ?>
+
+                <form method="post" action="options.php">
+                    <?php
+                    settings_fields( 'smmpw_settings' );
+                    do_settings_sections( 'smmpw-settings' );
+                    submit_button();
+                    ?>
+                </form>
+
+                <hr />
+
+                <h2><?php esc_html_e( 'Manual Synchronization', 'smmpw' ); ?></h2>
+                <p><?php esc_html_e( 'Use this option to immediately fetch services from your panel and sync them with WooCommerce.', 'smmpw' ); ?></p>
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                    <?php wp_nonce_field( 'smmpw_manual_sync' ); ?>
+                    <input type="hidden" name="action" value="smmpw_manual_sync" />
+                    <?php submit_button( __( 'Run Sync Now', 'smmpw' ), 'secondary' ); ?>
+                </form>
+
+                <h2><?php esc_html_e( 'Connection Test', 'smmpw' ); ?></h2>
+                <p><?php esc_html_e( 'Click the button below to test the API credentials and ensure the connection is working.', 'smmpw' ); ?></p>
+                <button class="button" id="smmpw-test-connection" data-nonce="<?php echo esc_attr( wp_create_nonce( 'smmpw_test_connection' ) ); ?>">
+                    <?php esc_html_e( 'Test Connection', 'smmpw' ); ?>
+                </button>
+                <span id="smmpw-test-response"></span>
+            </div>
+            <script>
+                (function($){
+                    $('#smmpw-test-connection').on('click', function(e){
+                        e.preventDefault();
+                        var $button = $(this);
+                        var $response = $('#smmpw-test-response');
+
+                        $button.prop('disabled', true);
+                        $response.text('<?php echo esc_js( __( 'Testing connection...', 'smmpw' ) ); ?>');
+
+                        $.post(ajaxurl, {
+                            action: 'smmpw_test_connection',
+                            nonce: $button.data('nonce')
+                        }).done(function(result){
+                            if(result.success){
+                                $response.text(result.data);
+                            } else {
+                                $response.text(result.data);
+                            }
+                        }).fail(function(){
+                            $response.text('<?php echo esc_js( __( 'Unable to connect. Check your credentials.', 'smmpw' ) ); ?>');
+                        }).always(function(){
+                            $button.prop('disabled', false);
+                        });
+                    });
+                })(jQuery);
+            </script>
+            <?php
+        }
+
+        /**
+         * Render text field.
+         *
+         * @param array $args Field arguments.
+         */
+        public function render_text_field( $args ) {
+            $settings = SMMPW_Plugin::instance()->get_settings();
+            $option   = $args['option'];
+            $type     = $args['type'] ?? 'text';
+            $value    = $settings[ $option ] ?? '';
+            $step     = $args['step'] ?? '';
+            ?>
+            <input type="<?php echo esc_attr( $type ); ?>" id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( SMMPW_Plugin::OPTION_SETTINGS . '[' . $option . ']' ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php if ( $step ) : ?>step="<?php echo esc_attr( $step ); ?>"<?php endif; ?> class="regular-text" />
+            <?php if ( ! empty( $args['help'] ) ) : ?>
+                <p class="description"><?php echo esc_html( $args['help'] ); ?></p>
+            <?php endif;
+        }
+
+        /**
+         * Render category dropdown field.
+         */
+        public function render_category_dropdown() {
+            $settings   = SMMPW_Plugin::instance()->get_settings();
+            $categories = get_terms( array(
+                'taxonomy'   => 'product_cat',
+                'hide_empty' => false,
+            ) );
+            ?>
+            <select id="smmpw_default_category" name="<?php echo esc_attr( SMMPW_Plugin::OPTION_SETTINGS . '[default_category]' ); ?>">
+                <option value="0" <?php selected( 0, $settings['default_category'] ); ?>><?php esc_html_e( '— Select —', 'smmpw' ); ?></option>
+                <?php foreach ( $categories as $category ) : ?>
+                    <option value="<?php echo esc_attr( $category->term_id ); ?>" <?php selected( $category->term_id, $settings['default_category'] ); ?>><?php echo esc_html( $category->name ); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <p class="description"><?php esc_html_e( 'Choose which category synchronized products will be assigned to by default.', 'smmpw' ); ?></p>
+            <?php
+        }
+
+        /**
+         * Render checkbox field.
+         *
+         * @param array $args Field arguments.
+         */
+        public function render_checkbox_field( $args ) {
+            $settings = SMMPW_Plugin::instance()->get_settings();
+            $option   = $args['option'];
+            $value    = ! empty( $settings[ $option ] );
+            ?>
+            <label>
+                <input type="checkbox" id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( SMMPW_Plugin::OPTION_SETTINGS . '[' . $option . ']' ); ?>" value="1" <?php checked( $value ); ?> />
+                <?php if ( ! empty( $args['description'] ) ) : ?>
+                    <?php echo esc_html( $args['description'] ); ?>
+                <?php endif; ?>
+            </label>
+            <?php
+        }
+
+        /**
+         * Render select field.
+         *
+         * @param array $args Field arguments.
+         */
+        public function render_select_field( $args ) {
+            $settings = SMMPW_Plugin::instance()->get_settings();
+            $option   = $args['option'];
+            $value    = $settings[ $option ] ?? '';
+            ?>
+            <select id="<?php echo esc_attr( $args['label_for'] ); ?>" name="<?php echo esc_attr( SMMPW_Plugin::OPTION_SETTINGS . '[' . $option . ']' ); ?>">
+                <?php foreach ( $args['options'] as $key => $label ) : ?>
+                    <option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $value ); ?>><?php echo esc_html( $label ); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <?php
+        }
+    }
+}

--- a/wp-content/plugins/smm-panel-connector/smm-panel-connector.php
+++ b/wp-content/plugins/smm-panel-connector/smm-panel-connector.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Plugin Name:       WooCommerce SMM Panel Connector
+ * Plugin URI:        https://example.com/
+ * Description:       Connect your WooCommerce store to your SMM panel or Perfect Panel instance, sync services, and sell them as WooCommerce products.
+ * Version:           1.0.0
+ * Author:            Your Company
+ * Author URI:        https://example.com/
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       smmpw
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'SMMPW_Plugin' ) ) {
+    /**
+     * Main plugin class responsible for bootstrapping admin UI and synchronization logic.
+     */
+    final class SMMPW_Plugin {
+        const VERSION          = '1.0.0';
+        const OPTION_SETTINGS  = 'smmpw_settings';
+        const CRON_HOOK        = 'smmpw_sync_products_event';
+
+        /**
+         * Singleton instance.
+         *
+         * @var SMMPW_Plugin
+         */
+        private static $instance;
+
+        /**
+         * Plugin bootstrap.
+         *
+         * @return SMMPW_Plugin
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Constructor registers hooks.
+         */
+        private function __construct() {
+            $this->define_constants();
+            $this->includes();
+
+            register_activation_hook( __FILE__, array( 'SMMPW_Plugin', 'activate' ) );
+            register_deactivation_hook( __FILE__, array( 'SMMPW_Plugin', 'deactivate' ) );
+
+            add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+            add_action( 'admin_menu', array( $this, 'register_settings_page' ) );
+            add_action( 'admin_init', array( $this, 'register_settings' ) );
+            add_action( 'admin_post_smmpw_manual_sync', array( $this, 'handle_manual_sync' ) );
+            add_action( self::CRON_HOOK, array( $this, 'sync_products' ) );
+
+            if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+                add_action( 'wp_ajax_smmpw_test_connection', array( $this, 'ajax_test_connection' ) );
+            }
+        }
+
+        /**
+         * Define plugin constants.
+         */
+        private function define_constants() {
+            if ( ! defined( 'SMMPW_PLUGIN_FILE' ) ) {
+                define( 'SMMPW_PLUGIN_FILE', __FILE__ );
+            }
+
+            if ( ! defined( 'SMMPW_PLUGIN_PATH' ) ) {
+                define( 'SMMPW_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+            }
+
+            if ( ! defined( 'SMMPW_PLUGIN_URL' ) ) {
+                define( 'SMMPW_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+            }
+        }
+
+        /**
+         * Load dependencies.
+         */
+        private function includes() {
+            require_once SMMPW_PLUGIN_PATH . 'includes/class-smmpw-settings-page.php';
+            require_once SMMPW_PLUGIN_PATH . 'includes/class-smmpw-service-sync.php';
+        }
+
+        /**
+         * Load plugin textdomain.
+         */
+        public function load_textdomain() {
+            load_plugin_textdomain( 'smmpw', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+        }
+
+        /**
+         * Register the settings page in the WooCommerce submenu.
+         */
+        public function register_settings_page() {
+            SMMPW_Settings_Page::instance();
+        }
+
+        /**
+         * Register plugin settings.
+         */
+        public function register_settings() {
+            register_setting( 'smmpw_settings', self::OPTION_SETTINGS, array( $this, 'sanitize_settings' ) );
+        }
+
+        /**
+         * Validate and sanitize plugin settings before saving.
+         *
+         * @param array $input Settings submitted via admin form.
+         *
+         * @return array Sanitized settings.
+         */
+        public function sanitize_settings( $input ) {
+            $output = array();
+
+            $output['api_url'] = isset( $input['api_url'] ) ? esc_url_raw( $input['api_url'] ) : '';
+            $output['api_key'] = isset( $input['api_key'] ) ? sanitize_text_field( $input['api_key'] ) : '';
+            $output['default_category'] = isset( $input['default_category'] ) ? absint( $input['default_category'] ) : 0;
+            $output['sync_pricing'] = ! empty( $input['sync_pricing'] );
+            $output['price_markup_type'] = in_array( $input['price_markup_type'] ?? 'percent', array( 'percent', 'fixed' ), true ) ? $input['price_markup_type'] : 'percent';
+            $output['price_markup_value'] = isset( $input['price_markup_value'] ) ? floatval( $input['price_markup_value'] ) : 0.0;
+            $output['stock_behavior'] = in_array( $input['stock_behavior'] ?? 'in_stock', array( 'in_stock', 'out_of_stock', 'remote' ), true ) ? $input['stock_behavior'] : 'in_stock';
+
+            $allowed_schedules = array( 'quarter_hour', 'hourly', 'twicedaily', 'daily' );
+            $requested_schedule = isset( $input['sync_schedule'] ) ? sanitize_text_field( $input['sync_schedule'] ) : 'hourly';
+            $output['sync_schedule'] = in_array( $requested_schedule, $allowed_schedules, true ) ? $requested_schedule : 'hourly';
+
+            $this->maybe_reschedule_event( $output['sync_schedule'] );
+
+            return $output;
+        }
+
+        /**
+         * Handle manual synchronization request.
+         */
+        public function handle_manual_sync() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                wp_die( esc_html__( 'You are not allowed to perform this action.', 'smmpw' ) );
+            }
+
+            check_admin_referer( 'smmpw_manual_sync' );
+
+            $result = $this->sync_products();
+
+            $redirect_url = add_query_arg(
+                array(
+                    'page'   => 'smmpw-settings',
+                    'synced' => $result ? '1' : '0',
+                ),
+                admin_url( 'admin.php' )
+            );
+
+            wp_safe_redirect( $redirect_url );
+            exit;
+        }
+
+        /**
+         * Test API connectivity via AJAX.
+         */
+        public function ajax_test_connection() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                wp_send_json_error( __( 'You are not allowed to perform this action.', 'smmpw' ), 403 );
+            }
+
+            check_ajax_referer( 'smmpw_test_connection', 'nonce' );
+
+            $settings = $this->get_settings();
+            $api      = new SMMPW_Service_Sync( $settings );
+
+            $response = $api->ping();
+
+            if ( is_wp_error( $response ) ) {
+                wp_send_json_error( $response->get_error_message() );
+            }
+
+            wp_send_json_success( __( 'Connection successful.', 'smmpw' ) );
+        }
+
+        /**
+         * Schedule synchronization event on activation.
+         */
+        public static function activate() {
+            $settings = get_option( self::OPTION_SETTINGS, array( 'sync_schedule' => 'hourly' ) );
+            $schedule = $settings['sync_schedule'] ?? 'hourly';
+
+            if ( ! wp_next_scheduled( self::CRON_HOOK ) && self::is_valid_schedule( $schedule ) ) {
+                wp_schedule_event( time() + MINUTE_IN_SECONDS, $schedule, self::CRON_HOOK );
+            }
+        }
+
+        /**
+         * Clear scheduled event on deactivation.
+         */
+        public static function deactivate() {
+            $timestamp = wp_next_scheduled( self::CRON_HOOK );
+            if ( $timestamp ) {
+                wp_unschedule_event( $timestamp, self::CRON_HOOK );
+            }
+        }
+
+        /**
+         * Ensure cron schedule matches saved setting.
+         *
+         * @param string $schedule Saved schedule.
+         */
+        private function maybe_reschedule_event( $schedule ) {
+            $timestamp = wp_next_scheduled( self::CRON_HOOK );
+            if ( $timestamp ) {
+                wp_unschedule_event( $timestamp, self::CRON_HOOK );
+            }
+
+            if ( ! empty( $schedule ) && self::is_valid_schedule( $schedule ) ) {
+                wp_schedule_event( time() + MINUTE_IN_SECONDS, $schedule, self::CRON_HOOK );
+            }
+        }
+
+        /**
+         * Validate that the provided schedule exists.
+         *
+         * @param string $schedule Cron schedule key.
+         *
+         * @return bool
+         */
+        private static function is_valid_schedule( $schedule ) {
+            $schedules = wp_get_schedules();
+
+            return isset( $schedules[ $schedule ] );
+        }
+
+        /**
+         * Retrieve plugin settings with defaults.
+         *
+         * @return array
+         */
+        public function get_settings() {
+            $defaults = array(
+                'api_url'            => '',
+                'api_key'            => '',
+                'default_category'   => 0,
+                'sync_pricing'       => true,
+                'price_markup_type'  => 'percent',
+                'price_markup_value' => 25,
+                'stock_behavior'     => 'in_stock',
+                'sync_schedule'      => 'hourly',
+            );
+
+            $settings = get_option( self::OPTION_SETTINGS, array() );
+
+            return wp_parse_args( $settings, $defaults );
+        }
+
+        /**
+         * Synchronize products with remote SMM panel.
+         *
+         * @return bool|
+         */
+        public function sync_products() {
+            if ( ! class_exists( 'WooCommerce' ) ) {
+                return false;
+            }
+
+            $settings = $this->get_settings();
+
+            if ( empty( $settings['api_url'] ) || empty( $settings['api_key'] ) ) {
+                return false;
+            }
+
+            $sync = new SMMPW_Service_Sync( $settings );
+
+            return $sync->sync();
+        }
+    }
+}
+
+// Register custom schedules.
+add_filter( 'cron_schedules', function ( $schedules ) {
+    if ( ! isset( $schedules['quarter_hour'] ) ) {
+        $schedules['quarter_hour'] = array(
+            'interval' => 15 * MINUTE_IN_SECONDS,
+            'display'  => __( 'Every 15 Minutes', 'smmpw' ),
+        );
+    }
+
+    if ( ! isset( $schedules['twice_daily'] ) ) {
+        $schedules['twice_daily'] = array(
+            'interval' => 12 * HOUR_IN_SECONDS,
+            'display'  => __( 'Twice Daily', 'smmpw' ),
+        );
+    }
+
+    return $schedules;
+} );
+
+// Bootstrap plugin.
+SMMPW_Plugin::instance();

--- a/wp-content/plugins/smm-panel-connector/uninstall.php
+++ b/wp-content/plugins/smm-panel-connector/uninstall.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Uninstall script for WooCommerce SMM Panel Connector.
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+delete_option( 'smmpw_settings' );


### PR DESCRIPTION
## Summary
- add a production-ready WooCommerce plugin that connects to Perfect Panel compatible SMM APIs
- implement admin settings for API credentials, pricing rules, cron scheduling, manual sync, and connection tests
- create synchronization service to fetch remote services and upsert WooCommerce products with pricing and metadata

## Testing
- php -l wp-content/plugins/smm-panel-connector/smm-panel-connector.php
- php -l wp-content/plugins/smm-panel-connector/includes/class-smmpw-settings-page.php
- php -l wp-content/plugins/smm-panel-connector/includes/class-smmpw-service-sync.php

------
https://chatgpt.com/codex/tasks/task_b_68da953738c88325a880993f598b671e