### PR TITLE
Ensure API key endpoint appears in customer account menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# smmpanelwordpress
-smmpanelwordpress
+# WooCommerce SMM Provider API
+
+Bu depo, WooCommerce mağazanızdaki servisleri Perfect Panel uyumlu SMM panellerine sağlayabilmeniz için hazırlanmış bir WordPress eklentisi içerir. Eklenti sayesinde mağazanızdan API URL ve anahtarları üretip bayilerinizin kendi panellerine ekleyebileceği tam fonksiyonel bir sağlayıcı API sunabilirsiniz.
+
+## Özellikler
+
+- Bayi bazlı API anahtarı üretme ve tek tıkla iptal edebilme
+- WooCommerce müşteri hesabında otomatik oluşan **API Anahtarı** menüsü ile kullanıcıların kendi anahtarlarını yönetebilmesi
+- API uç noktası adresini otomatik oluşturma ve yönetim panelinden paylaşma
+- WooCommerce ürünleri için minimum / maksimum adet ve 1000 başına fiyat tanımlama
+- Perfect Panel uyumlu `services`, `add`, `status` ve `balance` aksiyonlarını destekleme
+- API üzerinden gelen siparişleri otomatik olarak WooCommerce siparişlerine dönüştürme
+- API siparişleri için varsayılan sipariş durumu ve müşteri bilgileri belirleme
+- WooCommerce ürün listesinde hangi ürünlerin API üzerinden yayınlandığını gösterme
+
+## Kurulum
+
+1. Depoyu bilgisayarınıza klonlayın veya zip olarak indirin.
+2. `wp-content/plugins/smm-panel-connector` klasörünü WordPress kurulumunuzdaki `wp-content/plugins` dizinine kopyalayın.
+3. WordPress yönetim panelinden **Eklentiler > Yüklü Eklentiler** sayfasına gidin ve **WooCommerce SMM Provider API** eklentisini etkinleştirin.
+4. WooCommerce menüsü altında yer alan **SMM Provider API** sayfasına girerek genel ayarlarınızı yapın ve bayi anahtarları oluşturun.
+5. API üzerinden paylaşmak istediğiniz ürünlerde ürün düzenleme ekranındaki **Expose via SMM API** alanını aktif edin ve gerekli servis değerlerini doldurun.
+
+## API Kullanımı
+
+Reseller’larınız, ayarlar sayfasında gösterilen uç noktaya `key` ve `action` parametreleri ile istekte bulunabilir. Desteklenen aksiyonlar:
+
+- `services`: Aktif servisleri döndürür.
+- `add`: Yeni sipariş oluşturur. `service`, `quantity` ve `link` parametreleri zorunludur.
+- `status`: Sipariş durumunu sorgular. `order` parametresi zorunludur.
+- `balance`: Bakiye bilgisi döndürür (pay-as-you-go mantığında `0`).
+
+Tüm cevaplar JSON formatındadır ve Perfect Panel ile uyumlu alan isimleri içerir.
+
+## Geliştirme Notları
+
+- Eklenti ayarları `smmpw_provider_settings` opsiyonunda, API anahtarları `smmpw_api_keys` opsiyonunda saklanır.
+- Müşteri API anahtarları kullanıcı meta alanı `_smmpw_api_key` içerisinde tutulur ve My Account sayfasından yenilenebilir.
+- API üzerinden oluşturulan siparişler `_smmpw_api_order` meta değeriyle işaretlenir ve istenirse ek aksiyonlara bağlanabilir.
+- Kod standartları WordPress PHP kod standartlarını takip eder.
+
+Katkıda bulunurken kod stilini korumaya ve gereksiz değişikliklerden kaçınmaya özen gösterin.

--- a/wp-content/plugins/smm-panel-connector/assets/css/customer-keys.css
+++ b/wp-content/plugins/smm-panel-connector/assets/css/customer-keys.css
@@ -1,0 +1,67 @@
+.smmpw-dashboard-shortcut {
+    margin-bottom: 24px;
+}
+
+.smmpw-dashboard-shortcut__card {
+    display: block;
+    padding: 20px;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    background: #ffffff;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.smmpw-dashboard-shortcut__card:hover,
+.smmpw-dashboard-shortcut__card:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.smmpw-dashboard-shortcut__title {
+    display: block;
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.smmpw-dashboard-shortcut__meta-label {
+    display: block;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+    margin-bottom: 4px;
+}
+
+.smmpw-dashboard-shortcut__meta-value {
+    display: block;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 14px;
+    background: #f8fafc;
+    border-radius: 6px;
+    padding: 8px 10px;
+    margin-bottom: 12px;
+    color: #0f172a;
+    word-break: break-all;
+}
+
+.smmpw-dashboard-shortcut__cta {
+    display: inline-flex;
+    align-items: center;
+    font-weight: 600;
+    color: #2563eb;
+}
+
+.smmpw-dashboard-shortcut__cta::after {
+    content: "→";
+    margin-left: 8px;
+    transition: transform 0.2s ease;
+}
+
+.smmpw-dashboard-shortcut__card:hover .smmpw-dashboard-shortcut__cta::after,
+.smmpw-dashboard-shortcut__card:focus .smmpw-dashboard-shortcut__cta::after {
+    transform: translateX(4px);
+}

--- a/wp-content/plugins/smm-panel-connector/includes/class-smmpw-api-endpoint.php
+++ b/wp-content/plugins/smm-panel-connector/includes/class-smmpw-api-endpoint.php
@@ -1,0 +1,466 @@
+<?php
+/**
+ * Front-end API endpoint for Perfect Panel compatible integrations.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'SMMPW_API_Endpoint' ) ) {
+    /**
+     * Handles incoming API requests and converts them to WooCommerce orders.
+     */
+    class SMMPW_API_Endpoint {
+        /**
+         * Singleton instance.
+         *
+         * @var SMMPW_API_Endpoint|null
+         */
+        private static $instance = null;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @return SMMPW_API_Endpoint
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Constructor wires up hooks.
+         */
+        private function __construct() {
+            add_action( 'template_redirect', array( $this, 'maybe_handle_request' ), 0 );
+        }
+
+        /**
+         * Check if the current request targets the API and process it if so.
+         */
+        public function maybe_handle_request() {
+            if ( ! isset( $_GET['smmpw-api'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+                return;
+            }
+
+            $this->handle_request();
+        }
+
+        /**
+         * Process the API request.
+         */
+        private function handle_request() {
+            if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+                $params = wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification
+            } else {
+                $params = wp_unslash( $_GET ); // phpcs:ignore WordPress.Security.NonceVerification
+            }
+
+            $key = isset( $params['key'] ) ? sanitize_text_field( $params['key'] ) : '';
+            if ( empty( $key ) || ! $this->is_key_valid( $key ) ) {
+                $this->send_error( __( 'Invalid API key.', 'smmpw' ), 403 );
+            }
+
+            $action = isset( $params['action'] ) ? sanitize_key( $params['action'] ) : '';
+            if ( empty( $action ) ) {
+                $this->send_error( __( 'Missing API action.', 'smmpw' ) );
+            }
+
+            switch ( $action ) {
+                case 'services':
+                    $this->send_response( $this->get_services_response() );
+                    break;
+                case 'add':
+                    $this->handle_add_action( $params );
+                    break;
+                case 'status':
+                    $this->handle_status_action( $params );
+                    break;
+                case 'balance':
+                    $this->handle_balance_action();
+                    break;
+                default:
+                    $this->send_error( __( 'Unsupported action.', 'smmpw' ) );
+            }
+        }
+
+        /**
+         * Ensure the provided API key exists.
+         *
+         * @param string $key Raw API key.
+         *
+         * @return bool
+         */
+        private function is_key_valid( $key ) {
+            $keys = get_option( SMMPW_Plugin::OPTION_API_KEYS, array() );
+
+            if ( isset( $keys[ $key ] ) ) {
+                return true;
+            }
+
+            if ( class_exists( 'SMMPW_Customer_Keys' ) ) {
+                $user_ids = get_users(
+                    array(
+                        'meta_key'   => SMMPW_Customer_Keys::USER_META_KEY,
+                        'meta_value' => $key,
+                        'fields'     => 'ids',
+                        'number'     => 1,
+                    )
+                );
+
+                if ( ! empty( $user_ids ) ) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Build the services response payload.
+         *
+         * @return array
+         */
+        private function get_services_response() {
+            $products = wc_get_products(
+                array(
+                    'limit'      => -1,
+                    'status'     => array( 'publish' ),
+                    'meta_query' => array(
+                        array(
+                            'key'   => '_smmpw_api_enabled',
+                            'value' => 'yes',
+                        ),
+                    ),
+                )
+            );
+
+            $services = array();
+            $currency = get_woocommerce_currency();
+
+            foreach ( $products as $product ) {
+                $product_id = $product->get_id();
+                $service_id = get_post_meta( $product_id, '_smmpw_api_service_id', true );
+                $min        = get_post_meta( $product_id, '_smmpw_api_min', true );
+                $max        = get_post_meta( $product_id, '_smmpw_api_max', true );
+                $rate       = get_post_meta( $product_id, '_smmpw_api_rate', true );
+
+                if ( '' === $service_id ) {
+                    $service_id = (string) $product_id;
+                }
+
+                if ( '' === $rate ) {
+                    $price = (float) $product->get_price();
+                    $rate  = $price * 1000;
+                }
+
+                $categories = wp_get_post_terms( $product_id, 'product_cat', array( 'fields' => 'names' ) );
+
+                $services[] = array(
+                    'service'     => is_numeric( $service_id ) ? (int) $service_id : $service_id,
+                    'name'        => $product->get_name(),
+                    'category'    => ! empty( $categories ) ? $categories[0] : __( 'Uncategorized', 'smmpw' ),
+                    'type'        => 'default',
+                    'rate'        => number_format( (float) $rate, 4, '.', '' ),
+                    'min'         => (int) $min,
+                    'max'         => (int) $max,
+                    'description' => wp_strip_all_tags( $product->get_short_description() ),
+                    'currency'    => $currency,
+                );
+            }
+
+            return $services;
+        }
+
+        /**
+         * Handle `action=add` requests.
+         *
+         * @param array $params Request parameters.
+         */
+        private function handle_add_action( $params ) {
+            $service_id = isset( $params['service'] ) ? sanitize_text_field( $params['service'] ) : '';
+            $quantity   = isset( $params['quantity'] ) ? floatval( $params['quantity'] ) : 0;
+            $link       = isset( $params['link'] ) ? sanitize_text_field( $params['link'] ) : '';
+
+            if ( empty( $service_id ) ) {
+                $this->send_error( __( 'Service parameter is required.', 'smmpw' ) );
+            }
+
+            if ( $quantity <= 0 ) {
+                $this->send_error( __( 'Quantity must be greater than zero.', 'smmpw' ) );
+            }
+
+            if ( empty( $link ) ) {
+                $this->send_error( __( 'Link parameter is required.', 'smmpw' ) );
+            }
+
+            $product_id = $this->get_product_id_by_service_id( $service_id );
+            if ( ! $product_id ) {
+                $this->send_error( __( 'Service not found.', 'smmpw' ) );
+            }
+
+            $min = (float) get_post_meta( $product_id, '_smmpw_api_min', true );
+            $max = (float) get_post_meta( $product_id, '_smmpw_api_max', true );
+
+            if ( $min > 0 && $quantity < $min ) {
+                $this->send_error( sprintf( __( 'Quantity must be at least %s.', 'smmpw' ), $min ) );
+            }
+
+            if ( $max > 0 && $quantity > $max ) {
+                $this->send_error( sprintf( __( 'Quantity must be lower than or equal to %s.', 'smmpw' ), $max ) );
+            }
+
+            $charge = $this->calculate_charge( $product_id, $quantity );
+            if ( $charge <= 0 ) {
+                $this->send_error( __( 'Unable to calculate order charge.', 'smmpw' ) );
+            }
+
+            $order_id = $this->create_order( $product_id, $quantity, $charge, $link, $params );
+
+            $this->send_response(
+                array(
+                    'order'  => $order_id,
+                    'charge' => $charge,
+                    'currency' => get_woocommerce_currency(),
+                )
+            );
+        }
+
+        /**
+         * Handle `action=status` requests.
+         *
+         * @param array $params Request parameters.
+         */
+        private function handle_status_action( $params ) {
+            $order_id = isset( $params['order'] ) ? absint( $params['order'] ) : 0;
+            if ( ! $order_id ) {
+                $this->send_error( __( 'Order parameter is required.', 'smmpw' ) );
+            }
+
+            $order = wc_get_order( $order_id );
+            if ( ! $order || 'yes' !== $order->get_meta( '_smmpw_api_order', true ) ) {
+                $this->send_error( __( 'Order not found.', 'smmpw' ) );
+            }
+
+            $response = array(
+                'order'    => $order_id,
+                'status'   => $order->get_status(),
+                'charge'   => (float) $order->get_total(),
+                'link'     => $order->get_meta( '_smmpw_api_link', true ),
+                'quantity' => (float) $order->get_meta( '_smmpw_api_quantity', true ),
+                'currency' => $order->get_currency(),
+            );
+
+            $this->send_response( $response );
+        }
+
+        /**
+         * Handle `action=balance` requests. Since WooCommerce does not track reseller balances,
+         * we simply return zero to indicate pay-as-you-go behavior.
+         */
+        private function handle_balance_action() {
+            $this->send_response(
+                array(
+                    'balance'  => 0,
+                    'currency' => get_woocommerce_currency(),
+                )
+            );
+        }
+
+        /**
+         * Calculate the total charge for an API order.
+         *
+         * @param int   $product_id Product ID.
+         * @param float $quantity   Requested quantity.
+         *
+         * @return float
+         */
+        private function calculate_charge( $product_id, $quantity ) {
+            $rate = get_post_meta( $product_id, '_smmpw_api_rate', true );
+            if ( '' === $rate ) {
+                $product = wc_get_product( $product_id );
+                if ( ! $product ) {
+                    return 0;
+                }
+
+                $price = (float) $product->get_price();
+                $rate  = $price * 1000;
+            }
+
+            $charge = (float) $rate * ( (float) $quantity / 1000 );
+
+            return round( $charge, 4 );
+        }
+
+        /**
+         * Create a WooCommerce order for the API request.
+         *
+         * @param int   $product_id Product ID.
+         * @param float $quantity   Requested quantity.
+         * @param float $charge     Calculated charge.
+         * @param string $link      Target link submitted by the reseller.
+         * @param array  $params    Original request parameters for metadata.
+         *
+         * @return int Order ID.
+         */
+        private function create_order( $product_id, $quantity, $charge, $link, $params ) {
+            $settings = get_option( SMMPW_Plugin::OPTION_GENERAL_SETTINGS, array() );
+            $status   = isset( $settings['order_status'] ) ? $settings['order_status'] : 'wc-processing';
+
+            $order = wc_create_order();
+
+            if ( is_wp_error( $order ) ) {
+                $this->send_error( __( 'Failed to create order.', 'smmpw' ), 500 );
+            }
+
+            $item = new WC_Order_Item_Product();
+            $item->set_product_id( $product_id );
+            $item->set_quantity( 1 );
+            $item->set_total( $charge );
+            $item->set_subtotal( $charge );
+            $order->add_item( $item );
+
+            $order->update_meta_data( '_smmpw_api_order', 'yes' );
+            $order->update_meta_data( '_smmpw_api_service_id', $this->get_product_service_id( $product_id ) );
+            $order->update_meta_data( '_smmpw_api_quantity', $quantity );
+            $order->update_meta_data( '_smmpw_api_link', $link );
+            $order->update_meta_data( '_smmpw_api_raw_request', wp_json_encode( $this->sanitize_for_storage( $params ) ) );
+            if ( isset( $params['key'] ) ) {
+                $order->update_meta_data( '_smmpw_api_client_key', sanitize_text_field( $params['key'] ) );
+            }
+
+            $order->set_currency( get_woocommerce_currency() );
+            $order->set_payment_method( 'smmpw_api' );
+            $order->set_payment_method_title( __( 'SMM API', 'smmpw' ) );
+
+            $customer_name  = isset( $settings['default_customer_name'] ) ? $settings['default_customer_name'] : __( 'API Client', 'smmpw' );
+            $customer_email = isset( $settings['default_customer_email'] ) ? $settings['default_customer_email'] : get_option( 'admin_email' );
+
+            $name_parts = explode( ' ', trim( $customer_name ), 2 );
+
+            $billing = array(
+                'first_name' => $name_parts[0],
+                'last_name'  => isset( $name_parts[1] ) ? $name_parts[1] : '',
+                'email'      => $customer_email,
+            );
+
+            $order->set_address( $billing, 'billing' );
+            $order->set_total( $charge );
+            $order->calculate_taxes();
+            $order->save();
+
+            if ( 0 === strpos( $status, 'wc-' ) ) {
+                $status = substr( $status, 3 );
+            }
+
+            $order->update_status( $status );
+
+            /**
+             * Fires after an order has been created via the SMM API.
+             *
+             * @param int   $order_id Newly created order ID.
+             * @param array $params   Original request parameters.
+             */
+            do_action( 'smmpw_api_order_created', $order->get_id(), $this->sanitize_for_storage( $params ) );
+
+            return $order->get_id();
+        }
+
+        /**
+         * Convert request parameters into something safe for storage.
+         *
+         * @param array $params Request parameters.
+         *
+         * @return array
+         */
+        private function sanitize_for_storage( $params ) {
+            $safe = array();
+            foreach ( $params as $key => $value ) {
+                $safe_key = sanitize_key( $key );
+
+                if ( is_scalar( $value ) ) {
+                    $safe[ $safe_key ] = sanitize_text_field( (string) $value );
+                }
+            }
+
+            return $safe;
+        }
+
+        /**
+         * Resolve a product ID from the exposed service ID.
+         *
+         * @param string $service_id Service identifier shared with clients.
+         *
+         * @return int|false
+         */
+        private function get_product_id_by_service_id( $service_id ) {
+            global $wpdb;
+
+            $service_id = trim( $service_id );
+
+            $post_id = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s LIMIT 1",
+                    '_smmpw_api_service_id',
+                    $service_id
+                )
+            );
+
+            if ( $post_id ) {
+                return (int) $post_id;
+            }
+
+            if ( ctype_digit( $service_id ) ) {
+                $product = wc_get_product( (int) $service_id );
+                if ( $product && 'yes' === $product->get_meta( '_smmpw_api_enabled', true ) ) {
+                    return $product->get_id();
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Determine the service ID exposed to clients for a given product.
+         *
+         * @param int $product_id Product ID.
+         *
+         * @return string
+         */
+        private function get_product_service_id( $product_id ) {
+            $service_id = get_post_meta( $product_id, '_smmpw_api_service_id', true );
+
+            if ( '' === $service_id ) {
+                $service_id = (string) $product_id;
+            }
+
+            return $service_id;
+        }
+
+        /**
+         * Send a JSON response and exit.
+         *
+         * @param array $data Response payload.
+         */
+        private function send_response( $data ) {
+            nocache_headers();
+            wp_send_json( $data );
+        }
+
+        /**
+         * Send an error response and exit.
+         *
+         * @param string $message Human-readable error message.
+         * @param int    $status  HTTP status code.
+         */
+        private function send_error( $message, $status = 400 ) {
+            nocache_headers();
+            status_header( $status );
+            wp_send_json( array( 'error' => $message ) );
+        }
+    }
+}

--- a/wp-content/plugins/smm-panel-connector/includes/class-smmpw-customer-keys.php
+++ b/wp-content/plugins/smm-panel-connector/includes/class-smmpw-customer-keys.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Front-end customer tools for retrieving API credentials.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'SMMPW_Customer_Keys' ) ) {
+    /**
+     * Adds a "API Key" endpoint to the WooCommerce account area.
+     */
+    class SMMPW_Customer_Keys {
+        const USER_META_KEY = '_smmpw_api_key';
+        const ENDPOINT      = 'smmpw-api';
+
+        /**
+         * Singleton instance.
+         *
+         * @var SMMPW_Customer_Keys|null
+         */
+        private static $instance = null;
+
+        /**
+         * Retrieve the singleton instance.
+         *
+         * @return SMMPW_Customer_Keys
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Register rewrite endpoint on activation.
+         */
+        public static function activate() {
+            add_rewrite_endpoint( self::ENDPOINT, EP_ROOT | EP_PAGES );
+            flush_rewrite_rules();
+        }
+
+        /**
+         * Constructor wires up hooks for the My Account endpoint.
+         */
+        private function __construct() {
+            add_action( 'init', array( $this, 'register_endpoint' ) );
+            add_filter( 'woocommerce_get_query_vars', array( $this, 'register_query_var' ) );
+            add_filter( 'woocommerce_account_menu_items', array( $this, 'register_menu_item' ), 99 );
+            add_action( 'woocommerce_account_' . self::ENDPOINT . '_endpoint', array( $this, 'render_endpoint' ) );
+            add_action( 'admin_post_smmpw_generate_user_key', array( $this, 'handle_generate_key' ) );
+            add_action( 'admin_post_nopriv_smmpw_generate_user_key', array( $this, 'handle_generate_key' ) );
+        }
+
+        /**
+         * Register the pretty permalink endpoint.
+         */
+        public function register_endpoint() {
+            add_rewrite_endpoint( self::ENDPOINT, EP_ROOT | EP_PAGES );
+        }
+
+        /**
+         * Register endpoint query var so WooCommerce recognises it even with custom menus.
+         *
+         * @param array $query_vars Existing query vars.
+         *
+         * @return array
+         */
+        public function register_query_var( $query_vars ) {
+            $query_vars[ self::ENDPOINT ] = self::ENDPOINT;
+
+            return $query_vars;
+        }
+
+        /**
+         * Add the "API Key" item to the WooCommerce account navigation.
+         *
+         * @param array $items Existing items.
+         *
+         * @return array
+         */
+        public function register_menu_item( $items ) {
+            $label = __( 'API Anahtarı', 'smmpw' );
+
+            if ( isset( $items['customer-logout'] ) ) {
+                $logout = $items['customer-logout'];
+                unset( $items['customer-logout'] );
+
+                $items[ self::ENDPOINT ] = $label;
+                $items['customer-logout'] = $logout;
+
+                return $items;
+            }
+
+            $items[ self::ENDPOINT ] = $label;
+
+            return $items;
+        }
+
+        /**
+         * Render the endpoint content.
+         */
+        public function render_endpoint() {
+            if ( ! is_user_logged_in() ) {
+                esc_html_e( 'API anahtarınızı görüntülemek için giriş yapmalısınız.', 'smmpw' );
+                return;
+            }
+
+            $user_id = get_current_user_id();
+            $api_key = $this->get_user_key( $user_id );
+            $api_url = add_query_arg( 'smmpw-api', '1', home_url( '/' ) );
+
+            if ( function_exists( 'wc_print_notices' ) ) {
+                wc_print_notices();
+            }
+            ?>
+            <h3><?php esc_html_e( 'API Bilgileri', 'smmpw' ); ?></h3>
+            <p><?php esc_html_e( 'Bu bilgilerle Perfect Panel ve diğer paneller üzerinden sipariş oluşturabilirsiniz.', 'smmpw' ); ?></p>
+
+            <table class="shop_table shop_table_responsive">
+                <tbody>
+                    <tr>
+                        <th><?php esc_html_e( 'API URL', 'smmpw' ); ?></th>
+                        <td><code><?php echo esc_html( $api_url ); ?></code></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'API Key', 'smmpw' ); ?></th>
+                        <td>
+                            <?php if ( $api_key ) : ?>
+                                <code><?php echo esc_html( $api_key ); ?></code>
+                            <?php else : ?>
+                                <em><?php esc_html_e( 'Henüz bir API anahtarınız yok.', 'smmpw' ); ?></em>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                <?php wp_nonce_field( 'smmpw_generate_user_key' ); ?>
+                <input type="hidden" name="action" value="smmpw_generate_user_key" />
+                <button type="submit" class="button button-primary">
+                    <?php echo $api_key ? esc_html__( 'API Anahtarını Yenile', 'smmpw' ) : esc_html__( 'API Anahtarı Oluştur', 'smmpw' ); ?>
+                </button>
+            </form>
+            <?php
+        }
+
+        /**
+         * Handle the generate/regenerate key form submission.
+         */
+        public function handle_generate_key() {
+            if ( ! is_user_logged_in() ) {
+                $redirect = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : home_url();
+                wp_safe_redirect( $redirect );
+                exit;
+            }
+
+            check_admin_referer( 'smmpw_generate_user_key' );
+
+            $user_id = get_current_user_id();
+            $new_key = strtolower( wp_generate_password( 40, false, false ) );
+
+            update_user_meta( $user_id, self::USER_META_KEY, $new_key );
+
+            if ( function_exists( 'wc_add_notice' ) ) {
+                wc_add_notice( __( 'API anahtarınız başarıyla güncellendi.', 'smmpw' ), 'success' );
+            }
+
+            $endpoint_url = function_exists( 'wc_get_account_endpoint_url' ) ? wc_get_account_endpoint_url( self::ENDPOINT ) : home_url();
+
+            wp_safe_redirect( $endpoint_url );
+            exit;
+        }
+
+        /**
+         * Retrieve the stored API key for a user.
+         *
+         * @param int $user_id User ID.
+         *
+         * @return string
+         */
+        private function get_user_key( $user_id ) {
+            $key = get_user_meta( $user_id, self::USER_META_KEY, true );
+
+            return is_string( $key ) ? $key : '';
+        }
+    }
+}

--- a/wp-content/plugins/smm-panel-connector/includes/class-smmpw-product-meta.php
+++ b/wp-content/plugins/smm-panel-connector/includes/class-smmpw-product-meta.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Product metadata integration for mapping WooCommerce products to API services.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'SMMPW_Product_Meta' ) ) {
+    /**
+     * Adds meta boxes and saves data for products available through the API.
+     */
+    class SMMPW_Product_Meta {
+        /**
+         * Singleton instance.
+         *
+         * @var SMMPW_Product_Meta|null
+         */
+        private static $instance = null;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @return SMMPW_Product_Meta
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Constructor registers WooCommerce hooks.
+         */
+        private function __construct() {
+            add_action( 'woocommerce_product_options_general_product_data', array( $this, 'add_product_fields' ) );
+            add_action( 'woocommerce_admin_process_product_object', array( $this, 'save_product_fields' ), 10, 1 );
+            add_filter( 'manage_edit-product_columns', array( $this, 'add_product_column' ) );
+            add_action( 'manage_product_posts_custom_column', array( $this, 'render_product_column' ), 10, 2 );
+        }
+
+        /**
+         * Display custom product fields for API configuration.
+         */
+        public function add_product_fields() {
+            echo '<div class="options_group">';
+
+            woocommerce_wp_checkbox(
+                array(
+                    'id'          => '_smmpw_api_enabled',
+                    'label'       => __( 'Expose via SMM API', 'smmpw' ),
+                    'description' => __( 'Allow this product to appear in the Perfect Panel compatible API responses.', 'smmpw' ),
+                )
+            );
+
+            woocommerce_wp_text_input(
+                array(
+                    'id'          => '_smmpw_api_service_id',
+                    'label'       => __( 'Service ID', 'smmpw' ),
+                    'description' => __( 'Optional override for the service ID shown to resellers. Leave empty to use the product ID.', 'smmpw' ),
+                    'desc_tip'    => true,
+                )
+            );
+
+            woocommerce_wp_text_input(
+                array(
+                    'id'                => '_smmpw_api_min',
+                    'label'             => __( 'Minimum quantity', 'smmpw' ),
+                    'type'              => 'number',
+                    'description'       => __( 'Smallest quantity you are willing to accept from the API.', 'smmpw' ),
+                    'custom_attributes' => array(
+                        'min'  => '0',
+                        'step' => '1',
+                    ),
+                    'desc_tip'          => true,
+                )
+            );
+
+            woocommerce_wp_text_input(
+                array(
+                    'id'                => '_smmpw_api_max',
+                    'label'             => __( 'Maximum quantity', 'smmpw' ),
+                    'type'              => 'number',
+                    'description'       => __( 'Largest quantity the API should accept for a single order.', 'smmpw' ),
+                    'custom_attributes' => array(
+                        'min'  => '0',
+                        'step' => '1',
+                    ),
+                    'desc_tip'          => true,
+                )
+            );
+
+            woocommerce_wp_text_input(
+                array(
+                    'id'                => '_smmpw_api_rate',
+                    'label'             => __( 'API rate (per 1000)', 'smmpw' ),
+                    'type'              => 'number',
+                    'description'       => __( 'Rate charged per 1000 units for API orders. Leave blank to use the product price.', 'smmpw' ),
+                    'custom_attributes' => array(
+                        'min'  => '0',
+                        'step' => '0.0001',
+                    ),
+                    'desc_tip'          => true,
+                )
+            );
+
+            echo '</div>';
+        }
+
+        /**
+         * Persist product field values.
+         *
+         * @param WC_Product $product The product object being saved.
+         */
+        public function save_product_fields( $product ) {
+            $enabled = isset( $_POST['_smmpw_api_enabled'] ) ? 'yes' : 'no'; // phpcs:ignore WordPress.Security.NonceVerification
+            $product->update_meta_data( '_smmpw_api_enabled', $enabled );
+
+            $service_id = isset( $_POST['_smmpw_api_service_id'] ) ? sanitize_text_field( wp_unslash( $_POST['_smmpw_api_service_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+            $product->update_meta_data( '_smmpw_api_service_id', $service_id );
+
+            $min = isset( $_POST['_smmpw_api_min'] ) ? absint( wp_unslash( $_POST['_smmpw_api_min'] ) ) : '';// phpcs:ignore WordPress.Security.NonceVerification
+            $product->update_meta_data( '_smmpw_api_min', $min );
+
+            $max = isset( $_POST['_smmpw_api_max'] ) ? absint( wp_unslash( $_POST['_smmpw_api_max'] ) ) : '';// phpcs:ignore WordPress.Security.NonceVerification
+            $product->update_meta_data( '_smmpw_api_max', $max );
+
+            $rate = isset( $_POST['_smmpw_api_rate'] ) ? floatval( wp_unslash( $_POST['_smmpw_api_rate'] ) ) : '';// phpcs:ignore WordPress.Security.NonceVerification
+            $product->update_meta_data( '_smmpw_api_rate', $rate );
+        }
+
+        /**
+         * Add custom column to product list table.
+         *
+         * @param array $columns Existing columns.
+         *
+         * @return array
+         */
+        public function add_product_column( $columns ) {
+            $columns['smmpw_api'] = __( 'SMM API', 'smmpw' );
+
+            return $columns;
+        }
+
+        /**
+         * Render the custom column content.
+         *
+         * @param string $column Column key.
+         * @param int    $post_id Post ID.
+         */
+        public function render_product_column( $column, $post_id ) {
+            if ( 'smmpw_api' !== $column ) {
+                return;
+            }
+
+            $enabled    = get_post_meta( $post_id, '_smmpw_api_enabled', true );
+            $service_id = get_post_meta( $post_id, '_smmpw_api_service_id', true );
+
+            if ( 'yes' !== $enabled ) {
+                echo '&mdash;';
+
+                return;
+            }
+
+            if ( empty( $service_id ) ) {
+                $service_id = $post_id;
+            }
+
+            printf(
+                '<strong>%1$s</strong><br /><small>%2$s</small>',
+                esc_html__( 'Enabled', 'smmpw' ),
+                sprintf( esc_html__( 'Service ID: %s', 'smmpw' ), esc_html( $service_id ) )
+            );
+        }
+    }
+}

--- a/wp-content/plugins/smm-panel-connector/includes/class-smmpw-settings-page.php
+++ b/wp-content/plugins/smm-panel-connector/includes/class-smmpw-settings-page.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * Admin settings page for the WooCommerce SMM provider API.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'SMMPW_Settings_Page' ) ) {
+    /**
+     * Handles admin UI for managing API keys and general options.
+     */
+    class SMMPW_Settings_Page {
+        /**
+         * Singleton instance.
+         *
+         * @var SMMPW_Settings_Page|null
+         */
+        private static $instance = null;
+
+        /**
+         * Retrieve the singleton instance.
+         *
+         * @return SMMPW_Settings_Page
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Constructor registers admin hooks.
+         */
+        private function __construct() {
+            add_action( 'admin_menu', array( $this, 'register_menu' ) );
+            add_action( 'admin_init', array( $this, 'register_settings' ) );
+            add_action( 'admin_post_smmpw_add_key', array( $this, 'handle_add_key' ) );
+            add_action( 'admin_post_smmpw_revoke_key', array( $this, 'handle_revoke_key' ) );
+        }
+
+        /**
+         * Register the submenu page under WooCommerce.
+         */
+        public function register_menu() {
+            add_submenu_page(
+                'woocommerce',
+                __( 'SMM Provider API', 'smmpw' ),
+                __( 'SMM Provider API', 'smmpw' ),
+                'manage_woocommerce',
+                'smmpw-provider-settings',
+                array( $this, 'render_page' )
+            );
+        }
+
+        /**
+         * Register settings handled by the Settings API.
+         */
+        public function register_settings() {
+            register_setting(
+                'smmpw_provider_settings_group',
+                SMMPW_Plugin::OPTION_GENERAL_SETTINGS,
+                array( $this, 'sanitize_general_settings' )
+            );
+
+            add_settings_section(
+                'smmpw_provider_general_section',
+                __( 'General Settings', 'smmpw' ),
+                '__return_false',
+                'smmpw-provider-settings'
+            );
+
+            add_settings_field(
+                'smmpw_order_status',
+                __( 'API order status', 'smmpw' ),
+                array( $this, 'render_order_status_field' ),
+                'smmpw-provider-settings',
+                'smmpw_provider_general_section'
+            );
+
+            add_settings_field(
+                'smmpw_default_email',
+                __( 'Default customer email', 'smmpw' ),
+                array( $this, 'render_default_email_field' ),
+                'smmpw-provider-settings',
+                'smmpw_provider_general_section'
+            );
+
+            add_settings_field(
+                'smmpw_default_name',
+                __( 'Default customer name', 'smmpw' ),
+                array( $this, 'render_default_name_field' ),
+                'smmpw-provider-settings',
+                'smmpw_provider_general_section'
+            );
+        }
+
+        /**
+         * Sanitize general settings.
+         *
+         * @param array $settings Raw settings.
+         *
+         * @return array
+         */
+        public function sanitize_general_settings( $settings ) {
+            $current  = $this->get_general_settings();
+            $settings = is_array( $settings ) ? $settings : array();
+
+            $allowed_statuses = wc_get_order_statuses();
+            $status           = isset( $settings['order_status'] ) ? 'wc-' . sanitize_key( str_replace( 'wc-', '', $settings['order_status'] ) ) : 'wc-processing';
+            if ( ! isset( $allowed_statuses[ $status ] ) ) {
+                $status = 'wc-processing';
+            }
+
+            $current['order_status']          = $status;
+            $current['default_customer_email'] = isset( $settings['default_customer_email'] ) ? sanitize_email( wp_unslash( $settings['default_customer_email'] ) ) : '';
+            $current['default_customer_name']  = isset( $settings['default_customer_name'] ) ? sanitize_text_field( wp_unslash( $settings['default_customer_name'] ) ) : '';
+
+            return $current;
+        }
+
+        /**
+         * Render order status select field.
+         */
+        public function render_order_status_field() {
+            $settings = $this->get_general_settings();
+            $value    = isset( $settings['order_status'] ) ? $settings['order_status'] : 'wc-processing';
+            $statuses = wc_get_order_statuses();
+            ?>
+            <select name="<?php echo esc_attr( SMMPW_Plugin::OPTION_GENERAL_SETTINGS ); ?>[order_status]">
+                <?php foreach ( $statuses as $status_key => $status_label ) : ?>
+                    <option value="<?php echo esc_attr( $status_key ); ?>" <?php selected( $value, $status_key ); ?>><?php echo esc_html( $status_label ); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <p class="description"><?php esc_html_e( 'Orders created via the API will use this status.', 'smmpw' ); ?></p>
+            <?php
+        }
+
+        /**
+         * Render default customer email field.
+         */
+        public function render_default_email_field() {
+            $settings = $this->get_general_settings();
+            $value    = isset( $settings['default_customer_email'] ) ? $settings['default_customer_email'] : get_option( 'admin_email' );
+            ?>
+            <input type="email" class="regular-text" name="<?php echo esc_attr( SMMPW_Plugin::OPTION_GENERAL_SETTINGS ); ?>[default_customer_email]" value="<?php echo esc_attr( $value ); ?>" />
+            <p class="description"><?php esc_html_e( 'Used as the billing email for automatically created orders when no customer email is provided.', 'smmpw' ); ?></p>
+            <?php
+        }
+
+        /**
+         * Render default customer name field.
+         */
+        public function render_default_name_field() {
+            $settings = $this->get_general_settings();
+            $value    = isset( $settings['default_customer_name'] ) ? $settings['default_customer_name'] : __( 'API Client', 'smmpw' );
+            ?>
+            <input type="text" class="regular-text" name="<?php echo esc_attr( SMMPW_Plugin::OPTION_GENERAL_SETTINGS ); ?>[default_customer_name]" value="<?php echo esc_attr( $value ); ?>" />
+            <p class="description"><?php esc_html_e( 'Displayed as the billing name on API generated orders.', 'smmpw' ); ?></p>
+            <?php
+        }
+
+        /**
+         * Handle the add-key form submission.
+         */
+        public function handle_add_key() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                wp_die( esc_html__( 'You are not allowed to do that.', 'smmpw' ) );
+            }
+
+            check_admin_referer( 'smmpw_add_key' );
+
+            $label    = isset( $_POST['label'] ) ? sanitize_text_field( wp_unslash( $_POST['label'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+            $api_keys = $this->get_api_keys();
+            $key      = strtolower( wp_generate_password( 40, false, false ) );
+
+            $api_keys[ $key ] = array(
+                'label'   => $label,
+                'created' => time(),
+                'status'  => 'active',
+            );
+
+            update_option( SMMPW_Plugin::OPTION_API_KEYS, $api_keys );
+
+            wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=smmpw-provider-settings' ) );
+            exit;
+        }
+
+        /**
+         * Handle API key revocation.
+         */
+        public function handle_revoke_key() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                wp_die( esc_html__( 'You are not allowed to do that.', 'smmpw' ) );
+            }
+
+            check_admin_referer( 'smmpw_revoke_key' );
+
+            $key      = isset( $_POST['api_key'] ) ? sanitize_text_field( wp_unslash( $_POST['api_key'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+            $api_keys = $this->get_api_keys();
+
+            if ( isset( $api_keys[ $key ] ) ) {
+                unset( $api_keys[ $key ] );
+                update_option( SMMPW_Plugin::OPTION_API_KEYS, $api_keys );
+            }
+
+            wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=smmpw-provider-settings' ) );
+            exit;
+        }
+
+        /**
+         * Render the settings page.
+         */
+        public function render_page() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                wp_die( esc_html__( 'You are not allowed to view this page.', 'smmpw' ) );
+            }
+
+            $endpoint_url = add_query_arg( 'smmpw-api', '1', home_url( '/' ) );
+            $api_keys     = $this->get_api_keys();
+            ?>
+            <div class="wrap">
+                <h1><?php esc_html_e( 'SMM Provider API', 'smmpw' ); ?></h1>
+
+                <p><?php esc_html_e( 'Share the following API endpoint with your resellers. They can connect using any Perfect Panel compatible client.', 'smmpw' ); ?></p>
+                <p><code><?php echo esc_html( $endpoint_url ); ?></code></p>
+
+                <hr />
+
+                <form action="options.php" method="post">
+                    <?php
+                    settings_fields( 'smmpw_provider_settings_group' );
+                    do_settings_sections( 'smmpw-provider-settings' );
+                    submit_button();
+                    ?>
+                </form>
+
+                <hr />
+
+                <h2><?php esc_html_e( 'API Keys', 'smmpw' ); ?></h2>
+                <p><?php esc_html_e( 'Generate a unique key for each client to monitor access and revoke it if needed.', 'smmpw' ); ?></p>
+
+                <table class="widefat striped">
+                    <thead>
+                        <tr>
+                            <th><?php esc_html_e( 'Label', 'smmpw' ); ?></th>
+                            <th><?php esc_html_e( 'API Key', 'smmpw' ); ?></th>
+                            <th><?php esc_html_e( 'Created', 'smmpw' ); ?></th>
+                            <th><?php esc_html_e( 'Actions', 'smmpw' ); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if ( empty( $api_keys ) ) : ?>
+                            <tr>
+                                <td colspan="4"><?php esc_html_e( 'No API keys generated yet.', 'smmpw' ); ?></td>
+                            </tr>
+                        <?php else : ?>
+                            <?php foreach ( $api_keys as $key => $data ) : ?>
+                                <tr>
+                                    <td><?php echo esc_html( $data['label'] ?: __( 'Unnamed key', 'smmpw' ) ); ?></td>
+                                    <td><code><?php echo esc_html( $key ); ?></code></td>
+                                    <td><?php echo esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $data['created'] ) ); ?></td>
+                                    <td>
+                                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                                            <?php wp_nonce_field( 'smmpw_revoke_key' ); ?>
+                                            <input type="hidden" name="action" value="smmpw_revoke_key" />
+                                            <input type="hidden" name="api_key" value="<?php echo esc_attr( $key ); ?>" />
+                                            <?php submit_button( __( 'Revoke', 'smmpw' ), 'delete', 'submit', false ); ?>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+
+                <h3><?php esc_html_e( 'Create new API key', 'smmpw' ); ?></h3>
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                    <?php wp_nonce_field( 'smmpw_add_key' ); ?>
+                    <input type="hidden" name="action" value="smmpw_add_key" />
+                    <p>
+                        <label for="smmpw-label" class="screen-reader-text"><?php esc_html_e( 'Key label', 'smmpw' ); ?></label>
+                        <input type="text" id="smmpw-label" name="label" class="regular-text" placeholder="<?php esc_attr_e( 'Reseller name or note', 'smmpw' ); ?>" />
+                        <?php submit_button( __( 'Generate API key', 'smmpw' ), 'primary', 'submit', false ); ?>
+                    </p>
+                </form>
+            </div>
+            <?php
+        }
+
+        /**
+         * Retrieve saved API keys.
+         *
+         * @return array
+         */
+        public function get_api_keys() {
+            $keys = get_option( SMMPW_Plugin::OPTION_API_KEYS, array() );
+            if ( ! is_array( $keys ) ) {
+                $keys = array();
+            }
+
+            return $keys;
+        }
+
+        /**
+         * Retrieve general settings.
+         *
+         * @return array
+         */
+        public function get_general_settings() {
+            $defaults = array(
+                'order_status'           => 'wc-processing',
+                'default_customer_email' => get_option( 'admin_email' ),
+                'default_customer_name'  => __( 'API Client', 'smmpw' ),
+            );
+
+            $settings = get_option( SMMPW_Plugin::OPTION_GENERAL_SETTINGS, array() );
+            if ( ! is_array( $settings ) ) {
+                $settings = array();
+            }
+
+            return wp_parse_args( $settings, $defaults );
+        }
+    }
+}

--- a/wp-content/plugins/smm-panel-connector/smm-panel-connector.php
+++ b/wp-content/plugins/smm-panel-connector/smm-panel-connector.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Plugin Name:       WooCommerce SMM Provider API
+ * Plugin URI:        https://example.com/
+ * Description:       Expose your WooCommerce services through a Perfect Panel compatible SMM provider API endpoint.
+ * Version:           1.1.0
+ * Author:            Your Company
+ * Author URI:        https://example.com/
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       smmpw
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( class_exists( 'SMMPW_Plugin' ) ) {
+    return;
+}
+
+/**
+ * Bootstrap class for the SMM provider plugin.
+ */
+final class SMMPW_Plugin {
+        const VERSION                 = '1.1.0';
+        const OPTION_GENERAL_SETTINGS = 'smmpw_provider_settings';
+        const OPTION_API_KEYS         = 'smmpw_api_keys';
+
+        /**
+         * Singleton instance.
+         *
+         * @var SMMPW_Plugin|null
+         */
+        private static $instance = null;
+
+        /**
+         * Retrieve the singleton instance.
+         *
+         * @return SMMPW_Plugin
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Register activation hook.
+         */
+        public static function activate() {
+            if ( class_exists( 'SMMPW_Customer_Keys' ) ) {
+                SMMPW_Customer_Keys::activate();
+            }
+        }
+
+        /**
+         * Register deactivation hook.
+         */
+        public static function deactivate() {
+            // Nothing special yet, but keep hook for future use.
+        }
+
+        /**
+         * Constructor. Defines constants, loads dependencies, and registers hooks.
+         */
+        private function __construct() {
+            $this->define_constants();
+            $this->includes();
+
+            register_activation_hook( __FILE__, array( 'SMMPW_Plugin', 'activate' ) );
+            register_deactivation_hook( __FILE__, array( 'SMMPW_Plugin', 'deactivate' ) );
+
+            add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+            add_action( 'plugins_loaded', array( $this, 'maybe_bootstrap_woocommerce_features' ), 20 );
+            add_action( 'admin_init', array( $this, 'maybe_show_missing_wc_notice' ) );
+        }
+
+        /**
+         * Define reusable constants.
+         */
+        private function define_constants() {
+            if ( ! defined( 'SMMPW_PLUGIN_FILE' ) ) {
+                define( 'SMMPW_PLUGIN_FILE', __FILE__ );
+            }
+
+            if ( ! defined( 'SMMPW_PLUGIN_PATH' ) ) {
+                define( 'SMMPW_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+            }
+
+            if ( ! defined( 'SMMPW_PLUGIN_URL' ) ) {
+                define( 'SMMPW_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+            }
+        }
+
+        /**
+         * Include required class files.
+         */
+        private function includes() {
+            require_once SMMPW_PLUGIN_PATH . 'includes/class-smmpw-settings-page.php';
+            require_once SMMPW_PLUGIN_PATH . 'includes/class-smmpw-product-meta.php';
+            require_once SMMPW_PLUGIN_PATH . 'includes/class-smmpw-customer-keys.php';
+            require_once SMMPW_PLUGIN_PATH . 'includes/class-smmpw-api-endpoint.php';
+        }
+
+        /**
+         * Load plugin translations.
+         */
+        public function load_textdomain() {
+            load_plugin_textdomain( 'smmpw', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+        }
+
+        /**
+         * Initialise WooCommerce dependent features once WooCommerce is available.
+         */
+        public function maybe_bootstrap_woocommerce_features() {
+            if ( ! class_exists( 'WooCommerce' ) ) {
+                return;
+            }
+
+            SMMPW_Settings_Page::instance();
+            SMMPW_Product_Meta::instance();
+            SMMPW_Customer_Keys::instance();
+            SMMPW_API_Endpoint::instance();
+        }
+
+        /**
+         * Display an admin notice if WooCommerce is not active.
+         */
+        public function maybe_show_missing_wc_notice() {
+            if ( class_exists( 'WooCommerce' ) ) {
+                return;
+            }
+
+            add_action( 'admin_notices', array( $this, 'render_missing_wc_notice' ) );
+        }
+
+        /**
+         * Render the WooCommerce missing notice.
+         */
+        public function render_missing_wc_notice() {
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html__( 'WooCommerce SMM Provider API requires WooCommerce to be installed and active.', 'smmpw' )
+            );
+        }
+    }
+
+SMMPW_Plugin::instance();

--- a/wp-content/plugins/smm-panel-connector/uninstall.php
+++ b/wp-content/plugins/smm-panel-connector/uninstall.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Uninstall script for WooCommerce SMM Provider API.
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+delete_option( 'smmpw_provider_settings' );
+delete_option( 'smmpw_api_keys' );


### PR DESCRIPTION
## Summary
- register the customer API endpoint query var so WooCommerce recognises it
- adjust menu injection to append the API Key item just before logout with a late priority

## Testing
- php -l wp-content/plugins/smm-panel-connector/includes/class-smmpw-customer-keys.php

------
https://chatgpt.com/codex/tasks/task_b_68da953738c88325a880993f598b671e